### PR TITLE
(GH-70) Add validation for use of chocolatey dependency

### DIFF
--- a/docs/input/docs/rules/choco3003.md
+++ b/docs/input/docs/rules/choco3003.md
@@ -1,0 +1,28 @@
+﻿---
+Title: ChocolateyDependency
+Order: 30
+Description:
+Category: Notes
+---
+
+:::{.alert .alert-warning}
+**Preliminary Notice**
+This rule is not yet available in chocolatey-vscode.
+It is a planned rule for 0.8.0.
+:::
+
+**NOTE**: This page is a stub that has not yet been filled out. If you have questions about this issue, please ask in the review or reach out on [Gitter](https://gitter.im/chocolatey/chocolatey.org)
+
+## Issue
+
+In the nuspec,
+
+## Recommended Solution
+
+Please update _ so that _
+
+## Reasoning
+
+## See also
+
+- [Package validator rule](https://github.com/chocolatey/package-validator/wiki/ChocolateyDependency){target = _blank}

--- a/src/Chocolatey.Language.Server/Validations/IncludesChocolateyDependencyNote.cs
+++ b/src/Chocolatey.Language.Server/Validations/IncludesChocolateyDependencyNote.cs
@@ -1,0 +1,44 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.RegularExpressions;
+using Chocolatey.Language.Server.Models;
+using OmniSharp.Extensions.LanguageServer.Protocol.Models;
+using DiagnosticSeverity = OmniSharp.Extensions.LanguageServer.Protocol.Models.DiagnosticSeverity;
+
+namespace Chocolatey.Language.Server.Validations
+{
+    /// <summary>
+    /// Runs validation of the current nuspec to verify the dependency on the
+    /// chocolatey package ID.
+    /// </summary>
+    /// <seealso href="https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/IncludesChocolateyDependencyNote.cs">Package validator note for taking a dependency on Chocolatey.</seealso>
+    public sealed class IncludesChocolateyDependencyNote : NuspecRuleBase
+    {
+        /// <inheritdoc />
+        /// <summary>
+        /// Gets the string Id for the rule, similar to CHOCO0001
+        /// </summary>
+        public override string Id => "choco3003";
+
+        /// <inheritdoc />
+        /// <summary>
+        /// Gets the type of of validation
+        /// </summary>
+        public override ValidationType ValidationType => ValidationType.Note;
+
+        public override IEnumerable<Diagnostic> Validate(Package package)
+        {
+            var dependency = package.Dependencies.Any(x =>
+                string.Equals(x.Value.Id, "chocolatey", StringComparison.OrdinalIgnoreCase));
+            if (dependency)
+            {
+                yield return CreateDiagnostic(
+                    package.Dependencies.First().TextStart,
+                    package.Dependencies.Last().TextEnd,
+                    "The package takes a dependency on Chocolatey. The reviewer will ensure the package uses a specific Chocolatey feature that requires a minimum version."
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
Part of #70 

## Description
Added rule https://github.com/chocolatey/package-validator/blob/master/src/chocolatey.package.validator/infrastructure.app/rules/IncludesChocolateyDependencyNote.cs

## Related Issue
Related to #70 

## Motivation and Context
Adds another rule

## How Has This Been Tested?


## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
